### PR TITLE
Add slide-in panels for home cards

### DIFF
--- a/angular-portfolio/src/app/components/blog-card/blog-card.component.html
+++ b/angular-portfolio/src/app/components/blog-card/blog-card.component.html
@@ -1,9 +1,9 @@
-<article (click)="openModal()" class="blog-card group relative overflow-hidden transition-all duration-300 ease-in-out hover:scale-[1.02] hover:shadow-xl">
+<article (click)="onCardClick()" class="blog-card group relative overflow-hidden transition-all duration-300 ease-in-out hover:scale-[1.02] hover:shadow-xl">
   <h3 class="blog-card__title">{{ blog?.title || title }}</h3>
   <p class="blog-card__excerpt">{{ blog?.excerpt || excerpt }}</p>
   <footer class="blog-card__footer" (click)="$event.stopPropagation()">
     <ng-container *ngIf="blog; else linkTpl">
-      <button class="blog-card__link" (click)="openModal($event)">Read More</button>
+      <button class="blog-card__link" (click)="onReadMore($event)">Read More</button>
     </ng-container>
     <ng-template #linkTpl>
       <a [routerLink]="link" class="blog-card__link">Read More</a>

--- a/angular-portfolio/src/app/components/blog-card/blog-card.component.ts
+++ b/angular-portfolio/src/app/components/blog-card/blog-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { BlogModalComponent, BlogData } from '../blog-modal/blog-modal.component';
 
@@ -12,6 +12,7 @@ export class BlogCardComponent {
   @Input() excerpt = '';
   @Input() link = '';
   @Input() blog?: BlogData;
+  @Output() readMore = new EventEmitter<void>();
 
   constructor(private dialog: MatDialog) {}
 
@@ -29,5 +30,21 @@ export class BlogCardComponent {
       autoFocus: false,
       maxWidth: '90vw'
     });
+  }
+
+  onCardClick() {
+    if (this.readMore.observers.length) {
+      return;
+    }
+    this.openModal();
+  }
+
+  onReadMore(event: MouseEvent) {
+    event.stopPropagation();
+    if (this.readMore.observers.length) {
+      this.readMore.emit();
+    } else {
+      this.openModal();
+    }
   }
 }

--- a/angular-portfolio/src/app/home/home.component.html
+++ b/angular-portfolio/src/app/home/home.component.html
@@ -9,15 +9,64 @@
       [description]="project?.description"
       [image]="project?.image"
       [link]="project?.link"
+      (readMore)="openSlideIn(project!)"
     ></app-project-card>
     <a routerLink="/projects" class="home__link">View All Projects</a>
   </section>
   <section class="home__blog card">
     <app-blog-card
-      [title]="post?.title"
-      [excerpt]="post?.excerpt"
-      [link]="post?.link"
+      [title]="blog?.title"
+      [excerpt]="blog?.excerpt"
+      [link]="blog?.link"
+      [blog]="blog"
+      (readMore)="openBlogSlide(blog!)"
     ></app-blog-card>
   </section>
   <app-contact-cta></app-contact-cta>
+
+  <div
+    class="fixed inset-0 bg-black/70 z-40"
+    *ngIf="selectedProject"
+    (click)="closePanel()"
+  ></div>
+  <aside
+    *ngIf="selectedProject"
+    class="fixed top-0 right-0 h-full w-full max-w-lg bg-zinc-900 text-white z-50 shadow-xl transform transition-transform duration-300 ease-in-out"
+    [ngClass]="{ 'translate-x-0': selectedProject, 'translate-x-full': !selectedProject }"
+  >
+    <button class="absolute top-4 right-4 text-xl" (click)="closePanel()" aria-label="Close panel">✕</button>
+    <div class="p-6 space-y-4 overflow-y-auto h-full">
+      <h3 class="text-2xl font-semibold">{{ selectedProject?.title }}</h3>
+      <img *ngIf="selectedProject?.image" [src]="selectedProject?.image" alt="{{ selectedProject?.title }}" class="w-full h-48 object-cover rounded-md" />
+      <p>{{ selectedProject?.description }}</p>
+      <ul class="list-disc list-inside space-y-1">
+        <li *ngFor="let tech of selectedProject?.tech">{{ tech }}</li>
+      </ul>
+      <a
+        *ngIf="selectedProject?.liveLink"
+        [href]="selectedProject?.liveLink"
+        target="_blank"
+        class="inline-block bg-green-600 text-black px-4 py-2 rounded hover:bg-green-500 transition"
+        >Live Demo</a
+      >
+    </div>
+  </aside>
+
+  <div
+    class="fixed inset-0 bg-black/70 z-40"
+    *ngIf="selectedBlog"
+    (click)="closeBlogSlide()"
+  ></div>
+  <aside
+    *ngIf="selectedBlog"
+    class="fixed top-0 right-0 h-full w-full max-w-lg bg-zinc-900 text-white z-50 shadow-xl transform transition-transform duration-300 ease-in-out"
+    [ngClass]="{ 'translate-x-0': selectedBlog, 'translate-x-full': !selectedBlog }"
+  >
+    <button class="absolute top-4 right-4 text-xl" (click)="closeBlogSlide()" aria-label="Close panel">✕</button>
+    <div class="p-6 space-y-4 overflow-y-auto h-full">
+      <h3 class="text-2xl font-semibold">{{ selectedBlog?.title }}</h3>
+      <div class="text-gray-400 text-sm">{{ selectedBlog?.date }}</div>
+      <p class="whitespace-pre-line">{{ selectedBlog?.content }}</p>
+    </div>
+  </aside>
 </main>

--- a/angular-portfolio/src/app/home/home.component.ts
+++ b/angular-portfolio/src/app/home/home.component.ts
@@ -8,9 +8,11 @@ interface Project {
   link: string;
 }
 
-interface Post {
+interface Blog {
   title: string;
   excerpt: string;
+  content: string;
+  date: string;
   link: string;
 }
 
@@ -21,12 +23,30 @@ interface Post {
 })
 export class HomeComponent implements OnInit {
   project?: Project;
-  post?: Post;
+  blog?: Blog;
+  selectedProject: Project | null = null;
+  selectedBlog: Blog | null = null;
 
   constructor(private data: DataService) {}
 
   ngOnInit(): void {
     this.data.getProjects().subscribe(p => (this.project = p[0]));
-    this.data.getPosts().subscribe(b => (this.post = b[0]));
+    this.data.getPosts().subscribe(b => (this.blog = b[0]));
+  }
+
+  openSlideIn(project: Project) {
+    this.selectedProject = project;
+  }
+
+  closePanel() {
+    this.selectedProject = null;
+  }
+
+  openBlogSlide(blog: Blog) {
+    this.selectedBlog = blog;
+  }
+
+  closeBlogSlide() {
+    this.selectedBlog = null;
   }
 }


### PR DESCRIPTION
## Summary
- emit `readMore` from blog cards
- add slide‑in panels for project and blog cards on the home page

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876939db4d88331a3d7c7002b7cf611