### PR TITLE
Add slide-in panel for projects and blog modal on home

### DIFF
--- a/angular-portfolio/angular.json
+++ b/angular-portfolio/angular.json
@@ -19,6 +19,7 @@
               "zone.js"
             ],
             "tsConfig": "tsconfig.app.json",
+            "sourceMap": true,
             "assets": ["src/assets"],
             "styles": ["src/styles.scss"],
             "scripts": []

--- a/angular-portfolio/src/app/components/project-card/project-card.component.html
+++ b/angular-portfolio/src/app/components/project-card/project-card.component.html
@@ -21,14 +21,16 @@
     <p class="project-card__description text-sm mb-3" itemprop="description">
       {{ description }}
     </p>
-    <a href="#" (click)="onReadMore($event)" class="project-card__link text-green-400 hover:underline">Read More</a>
+    <button (click)="onReadMore($event)" class="project-card__link text-green-400 hover:underline" type="button">
+      Read More
+    </button>
   </div>
   <div
-    *ngIf="panelOpen"
+    *ngIf="selected"
     class="absolute top-0 right-0 h-full w-full max-w-md bg-zinc-900 text-white rounded-xl z-30 transform transition-transform duration-300 ease-in-out translate-x-full"
-    [class.translate-x-0]="panelVisible"
+    [class.translate-x-0]="selected"
   >
-    <button class="absolute top-4 right-4 text-xl" (click)="closePanel()" aria-label="Close panel">✕</button>
+    <button class="absolute top-4 right-4 text-xl" (click)="onClose($event)" aria-label="Close panel">✕</button>
     <div class="p-6 space-y-4 overflow-y-auto h-full">
       <h3 class="text-2xl font-semibold">{{ title }}</h3>
       <img *ngIf="image" [src]="image" alt="{{ title }}" class="w-full h-48 object-cover rounded-md" />

--- a/angular-portfolio/src/app/components/project-card/project-card.component.html
+++ b/angular-portfolio/src/app/components/project-card/project-card.component.html
@@ -23,4 +23,26 @@
     </p>
     <a href="#" (click)="onReadMore($event)" class="project-card__link text-green-400 hover:underline">Read More</a>
   </div>
+  <div
+    *ngIf="panelOpen"
+    class="absolute top-0 right-0 h-full w-full max-w-md bg-zinc-900 text-white rounded-xl z-30 transform transition-transform duration-300 ease-in-out translate-x-full"
+    [class.translate-x-0]="panelVisible"
+  >
+    <button class="absolute top-4 right-4 text-xl" (click)="closePanel()" aria-label="Close panel">✕</button>
+    <div class="p-6 space-y-4 overflow-y-auto h-full">
+      <h3 class="text-2xl font-semibold">{{ title }}</h3>
+      <img *ngIf="image" [src]="image" alt="{{ title }}" class="w-full h-48 object-cover rounded-md" />
+      <p>{{ description }}</p>
+      <ul *ngIf="techStack" class="list-disc list-inside space-y-1">
+        <li *ngFor="let tech of techStack">{{ tech }}</li>
+      </ul>
+      <a
+        *ngIf="liveLink"
+        [href]="liveLink"
+        target="_blank"
+        class="inline-block bg-green-600 text-black px-4 py-2 rounded hover:bg-green-500 transition"
+        >Live Demo</a
+      >
+    </div>
+  </div>
 </article>

--- a/angular-portfolio/src/app/components/project-card/project-card.component.ts
+++ b/angular-portfolio/src/app/components/project-card/project-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { trigger, transition, style, animate } from '@angular/animations';
 
 @Component({
@@ -22,8 +22,13 @@ export class ProjectCardComponent {
   @Input() techStack?: string[];
   @Input() liveLink?: string;
 
-  panelOpen = false;
-  panelVisible = false;
+  /** True when this card's slide-in panel should be visible */
+  @Input() selected = false;
+
+  /** Notify parent when user requests to open the panel */
+  @Output() readMore = new EventEmitter<void>();
+  /** Notify parent when the slide-in panel should close */
+  @Output() close = new EventEmitter<void>();
 
   imageLoaded = false;
 
@@ -33,12 +38,11 @@ export class ProjectCardComponent {
 
   onReadMore(event: Event) {
     event.preventDefault();
-    this.panelOpen = true;
-    setTimeout(() => (this.panelVisible = true));
+    this.readMore.emit();
   }
 
-  closePanel() {
-    this.panelVisible = false;
-    setTimeout(() => (this.panelOpen = false), 300);
+  onClose(event: Event) {
+    event.stopPropagation();
+    this.close.emit();
   }
 }

--- a/angular-portfolio/src/app/components/project-card/project-card.component.ts
+++ b/angular-portfolio/src/app/components/project-card/project-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { trigger, transition, style, animate } from '@angular/animations';
 
 @Component({
@@ -19,7 +19,11 @@ export class ProjectCardComponent {
   @Input() description = 'Project description';
   @Input() image = 'assets/placeholder.svg';
   @Input() link = '/projects/project-1';
-  @Output() readMore = new EventEmitter<void>();
+  @Input() techStack?: string[];
+  @Input() liveLink?: string;
+
+  panelOpen = false;
+  panelVisible = false;
 
   imageLoaded = false;
 
@@ -29,6 +33,12 @@ export class ProjectCardComponent {
 
   onReadMore(event: Event) {
     event.preventDefault();
-    this.readMore.emit();
+    this.panelOpen = true;
+    setTimeout(() => (this.panelVisible = true));
+  }
+
+  closePanel() {
+    this.panelVisible = false;
+    setTimeout(() => (this.panelOpen = false), 300);
   }
 }

--- a/angular-portfolio/src/app/home/home.component.html
+++ b/angular-portfolio/src/app/home/home.component.html
@@ -9,6 +9,8 @@
       [description]="project?.description"
       [image]="project?.image"
       [link]="project?.link"
+      [techStack]="project?.techStack"
+      [liveLink]="project?.liveLink"
     ></app-project-card>
     <a routerLink="/projects" class="home__link">View All Projects</a>
   </section>

--- a/angular-portfolio/src/app/home/home.component.html
+++ b/angular-portfolio/src/app/home/home.component.html
@@ -14,6 +14,7 @@
   </section>
   <section class="home__blog card">
     <app-blog-card
+      [blog]="post"
       [title]="post?.title"
       [excerpt]="post?.excerpt"
       [link]="post?.link"

--- a/angular-portfolio/src/app/home/home.component.html
+++ b/angular-portfolio/src/app/home/home.component.html
@@ -11,6 +11,9 @@
       [link]="project?.link"
       [techStack]="project?.techStack"
       [liveLink]="project?.liveLink"
+      [selected]="selectedProject === project"
+      (readMore)="openSlideIn(project)"
+      (close)="closePanel()"
     ></app-project-card>
     <a routerLink="/projects" class="home__link">View All Projects</a>
   </section>

--- a/angular-portfolio/src/app/home/home.component.ts
+++ b/angular-portfolio/src/app/home/home.component.ts
@@ -19,11 +19,20 @@ type Post = BlogData;
 export class HomeComponent implements OnInit {
   project?: Project;
   post?: Post;
+  selectedProject: Project | null = null;
 
   constructor(private data: DataService) {}
 
   ngOnInit(): void {
     this.data.getProjects().subscribe(p => (this.project = p[0]));
     this.data.getPosts().subscribe(b => (this.post = b[0]));
+  }
+
+  openSlideIn(project: Project) {
+    this.selectedProject = project;
+  }
+
+  closePanel() {
+    this.selectedProject = null;
   }
 }

--- a/angular-portfolio/src/app/home/home.component.ts
+++ b/angular-portfolio/src/app/home/home.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { DataService } from '../shared/data.service';
+import { BlogData } from '../components/blog-modal/blog-modal.component';
 
 interface Project {
   title: string;
@@ -8,11 +9,7 @@ interface Project {
   link: string;
 }
 
-interface Post {
-  title: string;
-  excerpt: string;
-  link: string;
-}
+type Post = BlogData;
 
 @Component({
   selector: 'app-home',

--- a/angular-portfolio/src/app/projects/projects.component.html
+++ b/angular-portfolio/src/app/projects/projects.component.html
@@ -8,5 +8,8 @@
     [link]="p.link"
     [techStack]="p.techStack"
     [liveLink]="p.liveLink"
+    [selected]="selectedProject === p"
+    (readMore)="openSlideIn(p)"
+    (close)="closePanel()"
   ></app-project-card>
 </section>

--- a/angular-portfolio/src/app/projects/projects.component.html
+++ b/angular-portfolio/src/app/projects/projects.component.html
@@ -1,35 +1,12 @@
 <section class="projects-page">
   <h2 class="projects-page__title">Projects</h2>
-  <div *ngFor="let p of projects" class="relative">
-    <app-project-card
-      [title]="p.title"
-      [description]="p.description"
-      [image]="p.image"
-      [link]="p.link"
-      (readMore)="openSlideIn(p)"
-    ></app-project-card>
-
-    <div
-      *ngIf="selectedProject === p"
-      class="absolute top-0 right-0 h-full w-full max-w-md bg-zinc-900 text-white rounded-xl z-30 transform transition-transform duration-300 ease-in-out translate-x-full"
-      [class.translate-x-0]="panelVisible"
-    >
-      <button class="absolute top-4 right-4 text-xl" (click)="closePanel()" aria-label="Close panel">✕</button>
-      <div class="p-6 space-y-4 overflow-y-auto h-full">
-        <h3 class="text-2xl font-semibold">{{ p.title }}</h3>
-        <img *ngIf="p.image" [src]="p.image" alt="{{ p.title }}" class="w-full h-48 object-cover rounded-md" />
-        <p>{{ p.description }}</p>
-        <ul *ngIf="p.techStack" class="list-disc list-inside space-y-1">
-          <li *ngFor="let tech of p.techStack">{{ tech }}</li>
-        </ul>
-        <a
-          *ngIf="p.liveLink"
-          [href]="p.liveLink"
-          target="_blank"
-          class="inline-block bg-green-600 text-black px-4 py-2 rounded hover:bg-green-500 transition"
-          >Live Demo</a
-        >
-      </div>
-    </div>
-  </div>
+  <app-project-card
+    *ngFor="let p of projects"
+    [title]="p.title"
+    [description]="p.description"
+    [image]="p.image"
+    [link]="p.link"
+    [techStack]="p.techStack"
+    [liveLink]="p.liveLink"
+  ></app-project-card>
 </section>

--- a/angular-portfolio/src/app/projects/projects.component.html
+++ b/angular-portfolio/src/app/projects/projects.component.html
@@ -1,39 +1,35 @@
 <section class="projects-page">
   <h2 class="projects-page__title">Projects</h2>
-  <app-project-card
-    *ngFor="let p of projects"
-    [title]="p.title"
-    [description]="p.description"
-    [image]="p.image"
-    [link]="p.link"
-    (readMore)="openSlideIn(p)"
-  ></app-project-card>
-</section>
+  <div *ngFor="let p of projects" class="relative">
+    <app-project-card
+      [title]="p.title"
+      [description]="p.description"
+      [image]="p.image"
+      [link]="p.link"
+      (readMore)="openSlideIn(p)"
+    ></app-project-card>
 
-<div
-  class="fixed inset-0 bg-black/70 z-40"
-  *ngIf="selectedProject"
-  (click)="closePanel()"
-></div>
-<aside
-  *ngIf="selectedProject"
-  class="fixed top-0 right-0 h-full w-full max-w-lg bg-zinc-900 text-white z-50 shadow-xl transform transition-transform duration-300 ease-in-out"
-  [ngClass]="{ 'translate-x-0': selectedProject, 'translate-x-full': !selectedProject }"
->
-  <button class="absolute top-4 right-4 text-xl" (click)="closePanel()" aria-label="Close panel">✕</button>
-  <div class="p-6 space-y-4 overflow-y-auto h-full">
-    <h3 class="text-2xl font-semibold">{{ selectedProject?.title }}</h3>
-    <img [src]="selectedProject?.image" alt="{{ selectedProject?.title }}" class="w-full h-48 object-cover rounded-md" />
-    <p>{{ selectedProject?.description }}</p>
-    <ul *ngIf="selectedProject?.techStack" class="list-disc list-inside space-y-1">
-      <li *ngFor="let tech of selectedProject?.techStack">{{ tech }}</li>
-    </ul>
-    <a
-      *ngIf="selectedProject?.demo"
-      [href]="selectedProject?.demo"
-      target="_blank"
-      class="inline-block bg-green-600 text-black px-4 py-2 rounded hover:bg-green-500 transition"
-      >Live Demo</a
+    <div
+      *ngIf="selectedProject === p"
+      class="absolute top-0 right-0 h-full w-full max-w-md bg-zinc-900 text-white rounded-xl z-30 transform transition-transform duration-300 ease-in-out translate-x-full"
+      [ngClass]="{ 'translate-x-0': selectedProject === p }"
     >
+      <button class="absolute top-4 right-4 text-xl" (click)="closePanel()" aria-label="Close panel">✕</button>
+      <div class="p-6 space-y-4 overflow-y-auto h-full">
+        <h3 class="text-2xl font-semibold">{{ p.title }}</h3>
+        <img *ngIf="p.image" [src]="p.image" alt="{{ p.title }}" class="w-full h-48 object-cover rounded-md" />
+        <p>{{ p.description }}</p>
+        <ul *ngIf="p.techStack" class="list-disc list-inside space-y-1">
+          <li *ngFor="let tech of p.techStack">{{ tech }}</li>
+        </ul>
+        <a
+          *ngIf="p.liveLink"
+          [href]="p.liveLink"
+          target="_blank"
+          class="inline-block bg-green-600 text-black px-4 py-2 rounded hover:bg-green-500 transition"
+          >Live Demo</a
+        >
+      </div>
+    </div>
   </div>
-</aside>
+</section>

--- a/angular-portfolio/src/app/projects/projects.component.html
+++ b/angular-portfolio/src/app/projects/projects.component.html
@@ -12,7 +12,7 @@
     <div
       *ngIf="selectedProject === p"
       class="absolute top-0 right-0 h-full w-full max-w-md bg-zinc-900 text-white rounded-xl z-30 transform transition-transform duration-300 ease-in-out translate-x-full"
-      [ngClass]="{ 'translate-x-0': selectedProject === p }"
+      [class.translate-x-0]="panelVisible"
     >
       <button class="absolute top-4 right-4 text-xl" (click)="closePanel()" aria-label="Close panel">✕</button>
       <div class="p-6 space-y-4 overflow-y-auto h-full">

--- a/angular-portfolio/src/app/projects/projects.component.ts
+++ b/angular-portfolio/src/app/projects/projects.component.ts
@@ -18,6 +18,7 @@ interface Project {
 export class ProjectsComponent implements OnInit {
   projects: Project[] = [];
   selectedProject: Project | null = null;
+  panelVisible = false;
 
   constructor(private data: DataService) {}
 
@@ -26,10 +27,15 @@ export class ProjectsComponent implements OnInit {
   }
 
   openSlideIn(project: Project) {
+    this.panelVisible = false;
     this.selectedProject = project;
+    // allow panel to render off-screen before sliding in
+    setTimeout(() => (this.panelVisible = true));
   }
 
   closePanel() {
-    this.selectedProject = null;
+    this.panelVisible = false;
+    // wait for animation to finish before removing element
+    setTimeout(() => (this.selectedProject = null), 300);
   }
 }

--- a/angular-portfolio/src/app/projects/projects.component.ts
+++ b/angular-portfolio/src/app/projects/projects.component.ts
@@ -17,10 +17,19 @@ interface Project {
 })
 export class ProjectsComponent implements OnInit {
   projects: Project[] = [];
+  selectedProject: Project | null = null;
 
   constructor(private data: DataService) {}
 
   ngOnInit(): void {
     this.data.getProjects().subscribe(p => (this.projects = p));
+  }
+
+  openSlideIn(project: Project) {
+    this.selectedProject = project;
+  }
+
+  closePanel() {
+    this.selectedProject = null;
   }
 }

--- a/angular-portfolio/src/app/projects/projects.component.ts
+++ b/angular-portfolio/src/app/projects/projects.component.ts
@@ -17,25 +17,10 @@ interface Project {
 })
 export class ProjectsComponent implements OnInit {
   projects: Project[] = [];
-  selectedProject: Project | null = null;
-  panelVisible = false;
 
   constructor(private data: DataService) {}
 
   ngOnInit(): void {
     this.data.getProjects().subscribe(p => (this.projects = p));
-  }
-
-  openSlideIn(project: Project) {
-    this.panelVisible = false;
-    this.selectedProject = project;
-    // allow panel to render off-screen before sliding in
-    setTimeout(() => (this.panelVisible = true));
-  }
-
-  closePanel() {
-    this.panelVisible = false;
-    // wait for animation to finish before removing element
-    setTimeout(() => (this.selectedProject = null), 300);
   }
 }

--- a/angular-portfolio/src/app/projects/projects.component.ts
+++ b/angular-portfolio/src/app/projects/projects.component.ts
@@ -6,6 +6,8 @@ interface Project {
   description: string;
   image: string;
   link: string;
+  techStack?: string[];
+  liveLink?: string;
 }
 
 @Component({

--- a/angular-portfolio/src/assets/projects.json
+++ b/angular-portfolio/src/assets/projects.json
@@ -3,18 +3,24 @@
     "title": "My Web App",
     "description": "A modern web application built with Angular.",
     "image": "assets/placeholder.svg",
-    "link": "/projects/my-web-app"
+    "link": "/projects/my-web-app",
+    "techStack": ["Angular", "Tailwind", "TypeScript"],
+    "liveLink": "https://example.com/my-web-app"
   },
   {
     "title": "Portfolio Site",
     "description": "Personal branding website built with SCSS styling.",
     "image": "assets/placeholder.svg",
-    "link": "/projects/portfolio-site"
+    "link": "/projects/portfolio-site",
+    "techStack": ["SCSS", "HTML", "JavaScript"],
+    "liveLink": "https://example.com/portfolio"
   },
   {
     "title": "E-commerce Platform",
     "description": "Full-featured online store with payment integration.",
     "image": "assets/placeholder.svg",
-    "link": "/projects/e-commerce"
+    "link": "/projects/e-commerce",
+    "techStack": ["Angular", "Stripe", "Firebase"],
+    "liveLink": "https://example.com/store"
   }
 ]


### PR DESCRIPTION
## Summary
- show slide-in project panel within the card container
- provide sample tech stack and live links in data
- allow homepage blog card to open modal with full content

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687697a994e883319e387db4ca85a7ca